### PR TITLE
Create Projects directory in Chef instead of doing it programmatically

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -138,7 +138,12 @@ directory "#{node.zeppelin.home}/logs" do
   action :create
 end
 
-
+directory "#{node.zeppelin.home}/Projects" do
+  owner node.zeppelin.user
+  group node.hops.group
+  mode "0770"
+  action :create
+end
 
 # Support for 'R' in apache zeppelin
 case node.platform_family


### PR DESCRIPTION
Create $ZEPPELIN_HOME/Projects sub-directory in Chef. PR https://github.com/hopshadoop/hopsworks-chef/pull/65 should also be merged in order for the user to be able to create the directory